### PR TITLE
Hide COVID info for mobile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "axios": "^0.19.2",
         "pm2": "^4.5.0",
         "react": "^16.13.1",
+        "react-device-detect": "^1.14.0",
         "react-dom": "^16.13.1",
         "react-router-dom": "^5.1.2"
       },
@@ -11953,6 +11954,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-device-detect": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-1.14.0.tgz",
+      "integrity": "sha512-fXFsZoTeLVrONrUr2sqCAXvnbouwyuqlBWoa3K92goCiPM1lUBvZqekv5TY3C02U/IrdoKLOBPFITYluwxKFyw==",
+      "dependencies": {
+        "ua-parser-js": "^0.7.22"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
+        "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
@@ -14919,6 +14932,14 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "node_modules/ua-parser-js": {
+      "version": "0.7.23",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
+      "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA==",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/uglify-js": {
       "version": "3.4.10",
@@ -26208,6 +26229,14 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-device-detect": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-1.14.0.tgz",
+      "integrity": "sha512-fXFsZoTeLVrONrUr2sqCAXvnbouwyuqlBWoa3K92goCiPM1lUBvZqekv5TY3C02U/IrdoKLOBPFITYluwxKFyw==",
+      "requires": {
+        "ua-parser-js": "^0.7.22"
+      }
+    },
     "react-dom": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
@@ -28707,6 +28736,11 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "ua-parser-js": {
+      "version": "0.7.23",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
+      "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA=="
     },
     "uglify-js": {
       "version": "3.4.10",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "axios": "^0.19.2",
     "pm2": "^4.5.0",
     "react": "^16.13.1",
+    "react-device-detect": "^1.14.0",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.1.2"
   },

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -7,6 +7,7 @@ import Card from '@material-ui/core/Card';
 import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
 import { makeStyles } from '@material-ui/core/styles';
+import { isMobile } from 'react-device-detect';
 
 import IconRegister from '@/assets/icon_register.svg';
 import heroWrapper from '@/assets/181144228-1.jpg';
@@ -182,8 +183,7 @@ const Home = () => {
         </Grid>
       </Container>
 
-      {/** Caregiver support line */}
-      <Container className={classes.ctaWrapper} maxWidth="sm">
+      {!isMobile && <Container className={classes.ctaWrapper} maxWidth="sm">
         <Grid container justify="center">
           <Card className={classes.card} variant="outlined">
             <CardContent>
@@ -208,7 +208,7 @@ const Home = () => {
             </CardActions>
           </Card>
         </Grid>
-      </Container>
+      </Container>}
 
       {/** CTA */}
       <Container className={classes.ctaWrapper} maxWidth="sm">


### PR DESCRIPTION
This is required instead of directing back to the main BC 211 site for COVID info on mobile devices. Mobile devices are detected by the main (WordPress) BC 211 site and redirected to `m.bc211.ca` (our landing page). To avoid this, we're removing the link and associated copy on mobile.

This is far from a perfect approach. It could also be that our mobile detection and that of the main (WordPress) BC 211 site vary slightly. The redirect loop could still be an issue in some edge cases. Tested with iPhone XR iOS 14.2 Safari and macOS 10.15.7 Safari 14.0.